### PR TITLE
Fix deleted file symptom for http-errors.log

### DIFF
--- a/openio-sds-logrotate/openio-sds-logrotate.conf
+++ b/openio-sds-logrotate/openio-sds-logrotate.conf
@@ -1,4 +1,5 @@
 /var/log/oio/sds/*/*/rawx*-httpd*.log {
+  copytruncate
   nodateext
   missingok
   notifempty

--- a/openio-sds-logrotate/openio-sds-logrotate.spec
+++ b/openio-sds-logrotate/openio-sds-logrotate.spec
@@ -1,5 +1,5 @@
 Name:		openio-sds-logrotate
-Version:	1.2
+Version:	1.3
 Release:	1%{?dist}
 Summary:	OpenIO SDS logrotate configuration
 BuildArch:	noarch
@@ -31,6 +31,8 @@ This package contains logrotate configuration for the OpenIO SDS solution.
 
 
 %changelog
+* Wed Apr 20 2016 - 1.2-1 - Sebastien Lapierre <sebastien.lapierre@openio.io>
+- Fix deleted file symptom for http-errors.log
 * Fri Mar 18 2016 - 1.2-1 - Romain Acciari <romain.acciari@openio.io>
 - Add event, account, rdir
 * Mon Jan 11 2016 - 1.1-1 - Romain Acciari <romain.acciari@openio.io>

--- a/openio-sds-logrotate/openio-sds-logrotate.spec
+++ b/openio-sds-logrotate/openio-sds-logrotate.spec
@@ -31,7 +31,7 @@ This package contains logrotate configuration for the OpenIO SDS solution.
 
 
 %changelog
-* Wed Apr 20 2016 - 1.2-1 - Sebastien Lapierre <sebastien.lapierre@openio.io>
+* Wed Apr 20 2016 - 1.3-1 - Sebastien Lapierre <sebastien.lapierre@openio.io>
 - Fix deleted file symptom for http-errors.log
 * Fri Mar 18 2016 - 1.2-1 - Romain Acciari <romain.acciari@openio.io>
 - Add event, account, rdir


### PR DESCRIPTION
avoid this:
    `httpd     35499           openio    2w      REG               0,66      2020      133524 /var/log/oio/sds/SCALAIR/rawx-10/rawx-10-httpd-errors.log.1 (deleted)`
    `httpd     35499           openio    6w      REG               0,66  10954033      133525 /var/log/oio/sds/SCALAIR/rawx-10/rawx-10-httpd-access.log.1 (deleted)`
    `httpd     35500           openio    2w      REG               0,66      1407      156111 /var/log/oio/sds/SCALAIR/rawx-21/rawx-21-httpd-errors.log.1 (deleted)`
    `httpd     35500           openio    6w      REG               0,66  10406481      156112 /var/log/oio/sds/SCALAIR/rawx-21/rawx-21-httpd-access.log.1 (deleted)`
    `httpd     35501           openio    2w      REG               0,66      3688         787 /var/log/oio/sds/SCALAIR/rawx-15/rawx-15-httpd-errors.log.1 (deleted)`