### PR TITLE
Update python-diamond-openio.spec

### DIFF
--- a/python-diamond-openio/python-diamond-openio.spec
+++ b/python-diamond-openio/python-diamond-openio.spec
@@ -1,5 +1,5 @@
 Name:           python-diamond-openio
-Version:        0.2
+Version:        0.3
 Release:        1%{?dist}
 Summary:        Diamond collector for OpenIO SDS
 
@@ -8,7 +8,7 @@ URL:            http://openio.io
 Source0:        openiosds.py
 
 #BuildRequires:  
-Requires:       python-diamond,python-oiopy,python-urllib3
+Requires:       python-diamond,openio-sds-server,python-urllib3
 
 %description
 Diamond collector for OpenIO SDS object storage solution.
@@ -31,6 +31,8 @@ Diamond collector for OpenIO SDS object storage solution.
 
 
 %changelog
+* Mon Aug 29 2016 Sebastien Lapierres <sebastien.lapierre@openio.io> - 0.3-1%{?dist}
+- change dependencies from oiopy (no longer used)  to openio-sds-server
 * Wed Mar 02 2016 Romain Acciari <romain.acciari@openio.io> - 0.2-1%{?dist}
 - New release
 * Fri Jan 29 2016 Romain Acciari <romain.acciari@openio.io> - 0.1-1%{?dist}


### PR DESCRIPTION
Replace obsolete dependence on python-oiopy to openio-sds-server.