### PR TITLE
Fix: filebeat compatibility and rawx unpleasantness logrotation, adjust openio-sds for 4.0.0

### DIFF
--- a/openio-sds-logrotate/openio-sds-logrotate.conf
+++ b/openio-sds-logrotate/openio-sds-logrotate.conf
@@ -1,19 +1,20 @@
-/var/log/oio/sds/*/*/rawx*-httpd*.log /var/log/oio/sds/*/*/ecd*-httpd*.log {
+/var/log/oio/sds/*/*/rawx*-httpd*.log {
   copytruncate
   nodateext
   missingok
   notifempty
   daily
-  maxsize 100M
+  maxsize 50M
   rotate 5
   compress
+  delaycompress
   sharedscripts
   postrotate
-    /bin/kill -HUP `cat /run/oio/sds/*-rawx*-httpd*.pid /run/oio/sds/*-ecd*-httpd*.pid` 2> /dev/null || true
+    /bin/kill -s USR1 `cat /run/oio/sds/*-rawx*-httpd*.pid /run/oio/sds/*-ecd*-httpd*.pid` 2> /dev/null || true
   endscript
 }
 
-/var/log/oio/sds/*/*/conscience*.log /var/log/oio/sds/*/*/conscience*.access /var/log/oio/sds/*/*/meta*.log /var/log/oio/sds/*/*/meta*.access /var/log/oio/sds/*/*/oioproxy*.log /var/log/oio/sds/*/*/oioproxy*.access /var/log/oio/sds/*/*/account*.log /var/log/oio/sds/*/*/account*.access /var/log/oio/sds/*/*/oio-event-agent*.log /var/log/oio/sds/*/*/rdir*.log /var/log/oio/sds/*/*/rdir*.access /var/log/oio/sds/*/*/oioswift*.log /var/log/oio/sds/*/*/replicator*.access /var/log/oio/sds/*/*/replicator*.log {
+/var/log/oio/sds/*/*/oio-blob-indexer-*.log  /var/log/oio/sds/*/*/conscience*.log /var/log/oio/sds/*/*/conscience*.access /var/log/oio/sds/*/*/meta*.log /var/log/oio/sds/*/*/meta*.access /var/log/oio/sds/*/*/oioproxy*.log /var/log/oio/sds/*/*/oioproxy*.access /var/log/oio/sds/*/*/account*.log /var/log/oio/sds/*/*/account*.access /var/log/oio/sds/*/*/oio-event-agent*.log /var/log/oio/sds/*/*/rdir*.log /var/log/oio/sds/*/*/rdir*.access /var/log/oio/sds/*/*/oioswift*.log /var/log/oio/sds/*/*/replicator*.access /var/log/oio/sds/*/*/replicator*.log {
   nodateext
   missingok
   notifempty
@@ -21,6 +22,7 @@
   maxsize 100M
   rotate 5
   compress
+  delaycompress
   sharedscripts
   postrotate
     /bin/kill -HUP `cat /run/*syslogd.pid 2> /dev/null` 2> /dev/null || true

--- a/openio-sds/openio-sds.spec
+++ b/openio-sds/openio-sds.spec
@@ -20,7 +20,7 @@ Source0:        https://github.com/open-io/oio-sds/archive/%{tarversion}.tar.gz
 Version:        test%{date}.git%{shortcommit}
 Release:        0%{?dist}
 %define         tarversion %{tag}
-%define         targetversion 3.3.0
+%define         targetversion 4.0.0
 Source0:        https://github.com/open-io/oio-sds/archive/%{tarversion}.tar.gz
 Epoch:          1
 %endif
@@ -269,7 +269,6 @@ PBR_VERSION=%{targetversion} %{__python} setup.py install -O1 --skip-build --roo
 %{_libdir}/libmetautils.so*
 %{_libdir}/libmeta0remote.so*
 %{_libdir}/libmeta1remote.so*
-%{_libdir}/libmeta2v2remote.so*
 %{_libdir}/liboio*
 # TODO find why libserver is necessary in common
 %{_libdir}/libserver.so*
@@ -356,6 +355,7 @@ PBR_VERSION=%{targetversion} %{__python} setup.py install -O1 --skip-build --roo
 %{_bindir}/%{cli_name}-crawler-integrity
 %{_bindir}/%{cli_name}-wrap.sh
 %{_bindir}/%{cli_name}-blob-registrator
+%{_bindir}/%{cli_name}-election-stat.py
 
 
 %pre common


### PR DESCRIPTION
- replace `kill -HUP` by `kill -s USR1` to prevent 404 errors while rawx logs are rotating
- add delaycompress for compatibility with filebeat 