### PR TITLE
New release: 4.1.5

### DIFF
--- a/openio-sds/openio-sds.spec
+++ b/openio-sds/openio-sds.spec
@@ -9,7 +9,7 @@
 Name:           openio-sds
 
 %if %{?_with_test:0}%{!?_with_test:1}
-Version:        4.1.4
+Version:        4.1.5
 Release:        1%{?dist}
 #%%define         tarversion %{version}
 %define         tarversion %{version}
@@ -379,6 +379,8 @@ fi
 /sbin/ldconfig
 
 %changelog
+* Fri Oct 27 2017 - 4.1.5-1 - Vincent Legoll <vincent.legoll@openio.io>
+- New release
 * Wed Oct 04 2017 - 4.1.4-1 - Romain Acciari <romain.acciari@openio.io>
 - New release
 * Tue Sep 12 2017 - 4.1.0-2 - Romain Acciari <romain.acciari@openio.io>


### PR DESCRIPTION
Test-built on docker openio/rpmbuild:
https://stackstorm.openio.io/#/history/59f2f475a013de095c1b8cb4/general

New version of the openio-sds package is available at repository:
http://mirror2.openio.io:80/pub/repo/vlegoll/sds/17.04/centos/7/x86_64
Repository signing public key:
http://mirror2.openio.io:80/pub/repo/openio/RPM-GPG-KEY-OPENIO-0
Build successful