### PR TITLE
[WIP] Remove oiopy packaging & SDS dependencies

### DIFF
--- a/oiofs-fuse/oiofs-fuse.spec
+++ b/oiofs-fuse/oiofs-fuse.spec
@@ -35,6 +35,7 @@ BuildRequires:  json-c-devel
 BuildRequires:  cmake >= 2.8.12
 BuildRequires:  python-setuptools
 BuildRequires:  libsoup-devel
+BuildRequires:  libattr-devel
 
 BuildRequires:  openio-sds-common-devel >= 4.0
 


### PR DESCRIPTION
Do not merge

This has not been tested, please review.

Were the removed dependencies just for oiopy's sake or are they still needed by other parts of the code ?

Will removing the "Provides" break something ?