### PR TITLE
New openio-rsyslog release: 1.3.1

### DIFF
--- a/openio-sds-rsyslog/openio-sds-rsyslog.spec
+++ b/openio-sds-rsyslog/openio-sds-rsyslog.spec
@@ -1,5 +1,5 @@
 Name:		openio-sds-rsyslog
-Version:	1.3.0
+Version:	1.3.1
 Release:	1%{?dist}
 Summary:	OpenIO SDS rsyslog configuration
 BuildArch:	noarch
@@ -50,6 +50,8 @@ fi
 
 
 %changelog
+* Thu Oct 04 2018 - 1.3.1-1 - Vincent Legoll <vincent.legoll@openio.io>
+- Fix serviceID with a PID in syslogtag
 * Mon Sep 24 2018 - 1.3.0-1 - Vincent Legoll <vincent.legoll@openio.io>
 - Set the right file owner
 * Fri Mar 06 2015 - 1.2-1 - Romain Acciari <romain.acciari@openio.io>


### PR DESCRIPTION
Fix serviceID with a PID in syslogtag