### PR TITLE
Update zookeeper to 3.5.5

### DIFF
--- a/zookeeper/01-zkpython-setup.patch
+++ b/zookeeper/01-zkpython-setup.patch
@@ -1,0 +1,17 @@
+--- zookeeper-contrib/zookeeper-contrib-zkpython/src/python/setup.py	2019-02-15 13:55:30.000000000 +0100
++++ zookeeper-contrib/zookeeper-contrib-zkpython/src/python/setup.py.new	2019-09-19 15:08:29.571195742 +0200
+@@ -16,11 +16,12 @@
+ 
+ from distutils.core import setup, Extension
+ 
+-zookeeper_basedir = "../../../"
++zookeeper_basedir = "../../"
+ 
+ zookeepermodule = Extension("zookeeper",
+-                            sources=["zookeeper-client/zookeeper-client-c/zookeeper.c"],
++                            sources=["src/c/zookeeper.c"],
+                             include_dirs=[zookeeper_basedir + "/zookeeper-client/zookeeper-client-c/include",
++                                          zookeeper_basedir + "/zookeeper-client/zookeeper-client-c",
+                                           zookeeper_basedir + "/build/c",
+                                           zookeeper_basedir + "/zookeeper-client/zookeeper-client-c/generated"],
+                             libraries=["zookeeper_mt"],

--- a/zookeeper/02-zkpython-module-init-return-value.patch
+++ b/zookeeper/02-zkpython-module-init-return-value.patch
@@ -1,0 +1,14 @@
+--- zookeeper-contrib/zookeeper-contrib-zkpython/src/c/zookeeper.c	2019-02-15 13:55:30.000000000 +0100
++++ zookeeper-contrib/zookeeper-contrib-zkpython/src/c/zookeeper.c.new	2019-09-19 16:19:37.475628597 +0200
+@@ -1563,7 +1563,11 @@
+   PyObject *module = Py_InitModule("zookeeper", ZooKeeperMethods);
+ #endif
+   if (init_zhandles(32) == 0) {
++#if PY_MAJOR_VERSION >= 3
++    return NULL;
++#else
+     return; // TODO: Is there any way to raise an exception here?
++#endif
+   }
+ 
+   ZooKeeperException = PyErr_NewException("zookeeper.ZooKeeperException",

--- a/zookeeper/ftbfs-with-gcc-8.patch
+++ b/zookeeper/ftbfs-with-gcc-8.patch
@@ -1,0 +1,14 @@
+Description: Address FTBFS with gcc-8 due to format-overflow
+Author: tony mancill <tmancill@debian.org>
+--- zookeeper-client/zookeeper-client-c/src/zookeeper.c	2019-09-26 17:32:56.930700994 +0200
++++ zookeeper-client/zookeeper-client-c/src/zookeeper.c.new	2019-09-26 17:32:46.970795829 +0200
+@@ -4381,7 +4381,7 @@
+ 
+ static const char* format_endpoint_info(const struct sockaddr_storage* ep)
+ {
+-    static char buf[128] = { 0 };
++    static char buf[128 + 6];	// include space for the port :xxxxx
+     char addrstr[128] = { 0 };
+     void *inaddr;
+ #ifdef _WIN32
+

--- a/zookeeper/zkEnv.patch
+++ b/zookeeper/zkEnv.patch
@@ -1,0 +1,24 @@
+--- bin/zkEnv.sh	2019-09-19 12:10:58.993465465 +0200
++++ bin/zkEnv.sh.new	2019-09-19 12:11:16.977075009 +0200
+@@ -25,6 +25,10 @@
+ # Or you can specify the ZOOCFGDIR using the
+ # '--config' option in the command line.
+ 
++# Adapted for SUSE
++ZOOCFGDIR="/etc/zookeeper"
++ZOO_LOG_DIR="/var/log/zookeeper"
++
+ ZOOBINDIR="${ZOOBINDIR:-/usr/bin}"
+ ZOOKEEPER_PREFIX="${ZOOBINDIR}/.."
+ 
+@@ -94,8 +98,8 @@
+ 
+ #make it work in the binary package
+ #(use array for LIBPATH to account for spaces within wildcard expansion)
+-if ls "${ZOOKEEPER_PREFIX}"/share/zookeeper/zookeeper-*.jar > /dev/null 2>&1; then 
+-  LIBPATH=("${ZOOKEEPER_PREFIX}"/share/zookeeper/*.jar)
++if ls "${ZOOKEEPER_PREFIX}"/share/java/zookeeper/zookeeper-*.jar > /dev/null 2>&1; then 
++  LIBPATH=("${ZOOKEEPER_PREFIX}"/share/java/zookeeper/*.jar)
+ else
+   #release tarball format
+   for i in "$ZOOBINDIR"/../zookeeper-*.jar

--- a/zookeeper/zookeeper.service
+++ b/zookeeper/zookeeper.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Apache ZooKeeper
+After=network.target
+ConditionPathExists=/etc/zookeeper/zoo.cfg
+ConditionPathExists=/etc/zookeeper/log4j.properties
+ConditionPathExists=/var/lib/zookeeper/data/myid
+
+[Service]
+Type=simple
+SyslogIdentifier=zookeeper
+WorkingDirectory=/var/lib/zookeeper
+ExecStart=/usr/bin/zkServer.sh start-foreground /etc/zookeeper/zoo.cfg
+ExecStop=/usr/bin/zkServer.sh stop
+
+User=zookeeper
+Group=zookeeper
+Restart=always
+RestartSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/zookeeper/zookeeper.spec
+++ b/zookeeper/zookeeper.spec
@@ -1,223 +1,287 @@
-#%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-%{!?python_sitearch: %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
+#
+# spec file for package zookeeper
+#
+# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
 
-Summary: High-performance coordination service for distributed applications.
-Name: zookeeper
-Version: 3.4.13
-Release: 1%{?dist}
-License: Apache License v2.0
-Group: Applications/Databases
-URL: http://hadoop.apache.org/zookeeper/
-#Source0: http://www-us.apache.org/dist/zookeeper/zookeeper-%{version}/zookeeper-%{version}.tar.gz
-Source0: https://archive.apache.org/dist/zookeeper/zookeeper-%{version}/zookeeper-%{version}.tar.gz
-Source1: zookeeper.init
-Source2: zookeeper.logrotate
-Source3: zoo.cfg
-Source4: log4j.properties
-Source5: java.env
-Patch0: ZOOKEEPER-critsects.patch
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires: python-devel
-BuildRequires: gcc,libtool
-BuildRequires: cppunit-devel
-Requires: logrotate, java
-Requires(post): chkconfig initscripts
-Requires(pre): chkconfig initscripts
-AutoReqProv: no
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+%define realname apache-zookeeper
+%define srcext   tar.gz
+%define so_ver   2
+
+Name:           zookeeper
+Version:        3.5.5
+Release:        0
+License:        Apache-2.0
+Summary:        A high-performance coordination service for distributed applications
+Group:          Development/Libraries/Java
+Url:            http://zookeeper.apache.org/
+Vendor:         Apache Software Foundation
+Source0:        http://www.apache.org/dist/zookeeper/%{name}-%{version}/%{realname}-%{version}-bin.%{srcext}
+Source1:        %{name}.service
+Source2:        http://www.apache.org/dist/zookeeper/%{name}-%{version}/%{realname}-%{version}.%{srcext}
+Patch0:         zkEnv.patch
+Patch1:         01-zkpython-setup.patch
+Patch2:         02-zkpython-module-init-return-value.patch
+Patch3:         ftbfs-with-gcc-8.patch
+BuildRequires:  autoconf automake libtool
+BuildRequires:  cppunit-devel
+%if 0%{?centos_ver} > 0
+# CentOS
+BuildRequires:  pkgconfig
+%else
+%if  0%{?suse_version}%{?fedora:9999} < 1550
+# Old Opensuse
+BuildRequires:  pkg-config
+%else
+# Opensuse Tumbleweed and Fedora
+BuildRequires:  pkgconf-pkg-config
+%endif
+%endif
+BuildRequires:  python-devel python-setuptools
+BuildRequires:  python3-devel python3-setuptools
+%if 0%{?suse_version} >= 1210
+BuildRequires:  systemd-rpm-macros
+%endif
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%{?systemd_requires}
 
 %description
-ZooKeeper is a distributed, open-source coordination service for distributed
-applications. It exposes a simple set of primitives that distributed
-applications can build upon to implement higher level services for
-synchronization, configuration maintenance, and groups and naming. It is
-designed to be easy to program to, and uses a data model styled after the
-familiar directory tree structure of file systems. It runs in Java and has
-bindings for both Java and C.
+ZooKeeper is a centralized service for maintaining configuration
+information, naming, providing distributed synchronization, and
+providing group services. All of these kinds of services are used in
+some form or another by distributed applications. Each time they are
+implemented there is a lot of work that goes into fixing the bugs and
+race conditions that are inevitable. Because of the difficulty of
+implementing these kinds of services, applications initially usually
+skimp on them ,which make them brittle in the presence of change and
+difficult to manage. Even when done correctly, different
+implementations of these services lead to management complexity when
+the applications are deployed.
 
-Coordination services are notoriously hard to get right. They are especially
-prone to errors such as race conditions and deadlock. The motivation behind
-ZooKeeper is to relieve distributed applications the responsibility of
-implementing coordination services from scratch.
+%package -n libzookeeper%{so_ver}
+Group:         System/Libraries
+Summary:       C interface to ZooKeeper
 
+Provides:      libzookeeper_mt%{so_ver} = %{version}-%{release}
+Provides:      libzookeeper_st%{so_ver} = %{version}-%{release}
+# CentOS compatibility
+Provides:      zookeeper-lib = %{version}-%{release}
+Obsoletes:     zookeeper-lib < 3.5
+
+%description -n libzookeeper%{so_ver}
+ZooKeeper is a centralized service for maintaining configuration
+information, naming, providing distributed synchronization, and
+providing group services.
+
+This package provides C interface library to ZooKeeper.
+
+%package devel
+Group:         Development/Libraries/C and C++
+Summary:       Development files for C interface to ZooKeeper
+
+Provides:      libzookeeper%{so_ver}-devel
+Provides:      libzookeeper-devel
+Provides:      libzookeeper_mt%{so_ver}-devel
+Provides:      libzookeeper_st%{so_ver}-devel
+Provides:      libzookeeper_mt-devel
+Provides:      libzookeeper_st-devel
+Requires:      libzookeeper%{so_ver} = %{version}-%{release}
+
+%description devel
+ZooKeeper is a centralized service for maintaining configuration
+information, naming, providing distributed synchronization, and
+providing group services.
+
+This package provides development stuff to build software against ZooKeeper.
+
+%package -n python2-zookeeper
+Summary:       Python client library for ZooKeeper
+Group:         Development/Libraries/Python
+Requires:      python2
+
+%description -n python2-zookeeper
+ZooKeeper is a centralized service for maintaining configuration
+information, naming, providing distributed synchronization, and
+providing group services.
+
+This package provides the Python3 client library for ZooKeeper.
+
+%package -n python3-zookeeper
+Summary:       Python client library for ZooKeeper
+Group:         Development/Libraries/Python
+Requires:      python3
+
+%description -n python3-zookeeper
+ZooKeeper is a centralized service for maintaining configuration
+information, naming, providing distributed synchronization, and
+providing group services.
+
+This package provides the Python3 client library for ZooKeeper.
 
 %prep
-%setup -q -n zookeeper-%{version}
-%patch0 -p1
+%setup -q -b 2 -n %{realname}-%{version}-bin
+%patch0
+sed -i 's/^dataDir=.*$/dataDir=\/var\/lib\/zookeeper\/data/' conf/zoo_sample.cfg
+sed -i 's,^#!/usr/bin/env bash,#!/bin/bash,' bin/*.sh
 
-pushd src/c
-rm -rf aclocal.m4 autom4te.cache/ config.guess config.status config.log \
-    config.sub configure depcomp install-sh ltmain.sh libtool \
-    Makefile Makefile.in missing stamp-h1 compile
-autoheader
-libtoolize --force
-aclocal
-automake -a
-autoconf
-autoreconf
-popd
+# Prepare C and Python APIs
+cd ../%{realname}-%{version}
+%patch1
+%patch2
+%patch3
+
+# C API
+cd zookeeper-client/zookeeper-client-c
+test -x configure || autoreconf --install
+cd ../..
+
+# Python API
+cd zookeeper-contrib/zookeeper-contrib-zkpython
+sed -E -e 's,(version = ")[^"]+,\1%{version},' -i src/python/setup.py
+cd ../..
 
 %build
-pushd src/c
+cd ../%{realname}-%{version}
+_CFLAGS='%{optflags} %{?gcc_lto}'
+_LDFLAGS='-Wl,--as-needed -Wl,--strip-all %{?gcc_lto}'
+cd zookeeper-client/zookeeper-client-c
 %configure \
-	--prefix=%{_prefix} \
-	--libdir=%{_libdir} \
-	--sysconfdir=/etc \
-	--enable-shared \
-	--disable-static
+ --disable-static \
+ --without-cppunit \
+ \
+ CFLAGS="$_CFLAGS -Wno-error=nonnull -Wno-error=unused-but-set-variable" \
+ LDFLAGS="$_LDFLAGS"
 %{__make} %{?_smp_mflags}
-popd
 
-# Build Python interface
-cd src/contrib/zkpython
-python src/python/setup.py build_ext -L $PWD/../../c/.libs
+cd ../..
+
+# Build python bindings
+cd zookeeper-contrib/zookeeper-contrib-zkpython
+PBR_VERSION=%{version} %{__python2} src/python/setup.py build_ext
+PBR_VERSION=%{version} %{__python3} src/python/setup.py build_ext
+cd ../..
+
 
 %install
-rm -rf $RPM_BUILD_ROOT
-%{__install} -p -d $RPM_BUILD_ROOT%{_libdir}/zookeeper  $RPM_BUILD_ROOT%{_bindir} $RPM_BUILD_ROOT%{_datadir}/zookeeper
-%{__install} bin/*.sh $RPM_BUILD_ROOT%{_bindir}/
-%{__install} lib/*.jar $RPM_BUILD_ROOT%{_datadir}/zookeeper/
-%{__install} -p -D -m 644 zookeeper-%{version}.jar $RPM_BUILD_ROOT%{_datadir}/zookeeper/zookeeper-%{version}.jar
-%{__mkdir_p} $RPM_BUILD_ROOT%{_sysconfdir}/zookeeper
+# Precompiled Java libraries and dependencies
+mkdir -p %{buildroot}%{_javadir}
+mkdir -p %{buildroot}%{_javadir}/%{name}
+cp -r lib/* %{buildroot}%{_javadir}/%{name}
+(cd %{buildroot}%{_javadir}/%{name} && for jar in *-%{version}*.jar; do ln -sf ${jar} `echo $jar| sed -e "s|-%{version}||g"`; done)
 
-# Install init script
-%{__install} -p -D -m 755 %{S:1} $RPM_BUILD_ROOT%{_initrddir}/zookeeper
+# Scripts
+mkdir -p %{buildroot}%{_bindir}
+install -p -m 755 bin/zkCleanup.sh %{buildroot}%{_bindir}
+install -p -m 755 bin/zkCli.sh %{buildroot}%{_bindir}
+install -p -m 755 bin/zkEnv.sh %{buildroot}%{_bindir}
+install -p -m 755 bin/zkServer.sh %{buildroot}%{_bindir}
 
-# Install config files
-%{__install} -p -D -m 644 %{S:2} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
-%{__install} -p -D -m 644 %{S:3} $RPM_BUILD_ROOT%{_sysconfdir}/zookeeper/zoo.cfg
-%{__install} -p -D -m 644 %{S:4} $RPM_BUILD_ROOT%{_sysconfdir}/zookeeper/log4j.properties
-%{__install} -p -D -m 644 %{S:5} $RPM_BUILD_ROOT%{_sysconfdir}/zookeeper/java.env
-%{__install} -p -D -m 644 conf/configuration.xsl $RPM_BUILD_ROOT%{_sysconfdir}/zookeeper/configuration.xsl
+mkdir -p %{buildroot}%{_sysconfdir}/zookeeper
+install -p -m 0640 conf/log4j.properties %{buildroot}%{_sysconfdir}/zookeeper
+install -p -m 0640 conf/zoo_sample.cfg %{buildroot}%{_sysconfdir}/zookeeper
+touch %{buildroot}%{_sysconfdir}/zookeeper/zoo.cfg
 
-# Link scripts to human readable command
-%{__install} -d $RPM_BUILD_ROOT%{_sbindir}
-ln -sf %{_bindir}/zkServer.sh $RPM_BUILD_ROOT%{_sbindir}/zookeeper-server
-ln -sf %{_bindir}/zkCleanup.sh $RPM_BUILD_ROOT%{_sbindir}/zookeeper-cleanup
-ln -sf %{_bindir}/zkCli.sh $RPM_BUILD_ROOT%{_bindir}/zookeeper-cli
+mkdir -p %{buildroot}/var/lib/zookeeper/data
+touch %{buildroot}/var/lib/zookeeper/data/myid
 
-# Create var directories
-%{__install} -d $RPM_BUILD_ROOT%{_localstatedir}/log/zookeeper
-%{__install} -d $RPM_BUILD_ROOT%{_localstatedir}/lib/zookeeper
-%{__install} -d $RPM_BUILD_ROOT%{_localstatedir}/lib/zookeeper/data
-%{__install} -p -d -D -m 0755 $RPM_BUILD_ROOT%{_datadir}/zookeeper
+mkdir -p %{buildroot}/var/log/zookeeper
 
-# Install C components
-%{makeinstall} -C src/c
+install -D -m 644 %{S:1} %{buildroot}%{_unitdir}/%{name}.service
+mkdir -p %{buildroot}%{_sbindir}
+ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rc%{name}
 
-# Kludge for ugly default path
-#mv $RPM_BUILD_ROOT%{_includedir}/c-client-src $RPM_BUILD_ROOT%{_includedir}/zookeeper
+# C API library
+cd ../%{realname}-%{version}
+%{__make} -C zookeeper-client/zookeeper-client-c install DESTDIR=%{buildroot}
 
-# Install Python stuff
-cd src/contrib/zkpython
-python src/python/setup.py install --install-lib $RPM_BUILD_ROOT%{python_sitearch}
+# Python libraries
+cd zookeeper-contrib/zookeeper-contrib-zkpython
+PBR_VERSION=%{version} %{__python2} src/python/setup.py install \
+    -O1 --skip-build --root $RPM_BUILD_ROOT
+PBR_VERSION=%{version} %{__python3} src/python/setup.py install \
+    -O1 --skip-build --root $RPM_BUILD_ROOT
+cd ../..
 
-%clean
-rm -rf $RPM_BUILD_ROOT
+%pre
+groupadd --system zookeeper 2>/dev/null || :
+useradd -g zookeeper -r -d /var/lib/zookeeper -s /bin/false \
+        -c "ZooKeeper service account" zookeeper 2>/dev/null || :
+
+%service_add_pre %{name}.service
+
+%post
+ZK_CLASSPATH=%{_javadir}/%{name}.jar:$(find %{_javadir}/%{name} -name "*.jar" -printf %p:)
+echo "CLASSPATH=$ZK_CLASSPATH" > %{_sysconfdir}/zookeeper/java.env
+/sbin/ldconfig > /dev/null 2>&1
+%service_add_post %{name}.service
+
+%preun
+%service_del_preun %{name}.service
+
+%postun
+/sbin/ldconfig > /dev/null 2>&1
+%service_del_postun %{name}.service
+
+%post   -n libzookeeper%{so_ver} -p /sbin/ldconfig
+%postun -n libzookeeper%{so_ver} -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root,-)
-#%doc LICENSE.txt NOTICE.txt README.txt
-%doc LICENSE.txt NOTICE.txt
-%doc docs recipes
-%dir %attr(0750, zookeeper, zookeeper) %{_localstatedir}/lib/zookeeper
-%dir %attr(0750, zookeeper, zookeeper) %{_localstatedir}/lib/zookeeper/data
-%dir %attr(0750, zookeeper, zookeeper) %{_localstatedir}/log/zookeeper
-%{_initrddir}/zookeeper
-%config(noreplace) %{_sysconfdir}/logrotate.d/zookeeper
-%config(noreplace) %{_sysconfdir}/zookeeper
-%{_sbindir}/*
-%{_bindir}/*
-%{_datadir}/zookeeper
+%doc LICENSE.txt NOTICE.txt README.md
+%{_bindir}/*.sh
+%dir %{_javadir}/%{name}
+%{_javadir}/%{name}/*
+%attr(0750,zookeeper,zookeeper) %dir /var/lib/zookeeper
+%attr(0750,zookeeper,zookeeper) %dir /var/lib/zookeeper/data
+%attr(0640,zookeeper,zookeeper) %ghost /var/lib/zookeeper/data/myid
+%attr(0755,zookeeper,zookeeper) %dir /var/log/zookeeper
+%attr(0755,root,root) %dir %{_sysconfdir}/zookeeper
+%attr(0644,root,root) %ghost %config(noreplace) %{_sysconfdir}/zookeeper/zoo.cfg
+%config %attr(0644,root,root) %{_sysconfdir}/zookeeper/zoo_sample.cfg
+%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/zookeeper/log4j.properties
+%{_unitdir}/%{name}.service
+%{_sbindir}/rc%{name}
 
-# ------------------------------ libzookeeper ------------------------------
+# Development stuff
+%files devel
+%defattr(-,root,root)
+%{_includedir}/zookeeper/
+%{_libdir}/*.so
+%exclude %{_libdir}/*.la
 
-%package lib
-Summary: C client interface to zookeeper server
-Group: Development/Libraries
-BuildRequires: gcc
+%files -n libzookeeper%{so_ver}
+%defattr(-,root,root)
+%doc ../%{realname}-%{version}/zookeeper-client/zookeeper-client-c/{LICENSE,NOTICE.txt,README}
+%{_bindir}/cli*
+%{_bindir}/load_gen
+%{_libdir}/libzookeeper_mt.so.%{so_ver}*
+%{_libdir}/libzookeeper_st.so.%{so_ver}*
 
-%description lib
-The client supports two types of APIs -- synchronous and asynchronous.
- 
-Asynchronous API provides non-blocking operations with completion callbacks and
-relies on the application to implement event multiplexing on its behalf.
- 
-On the other hand, Synchronous API provides a blocking flavor of
-zookeeper operations and runs its own event loop in a separate thread.
- 
-Sync and Async APIs can be mixed and matched within the same application.
-
-%files lib
+%files -n python2-zookeeper
 %defattr(-, root, root, -)
-%doc src/c/README src/c/LICENSE
-%{_libdir}/libzookeeper_mt.so*
-%{_libdir}/libzookeeper_st.so*
-
-# ------------------------------ libzookeeper-devel ------------------------------
-
-%package lib-devel
-Summary: Headers and static libraries for libzookeeper
-Group: Development/Libraries
-Requires: %{name}-lib
-Requires: gcc
-
-%description lib-devel
-This package contains the libraries and header files needed for
-developing with libzookeeper.
-
-%files lib-devel
-%defattr(-, root, root, -)
-%{_includedir}/*
-%{_libdir}/*.la
-
-# ------------------------------ Python ------------------------------
-
-%package -n python-ZooKeeper
-Summary: Python client library for ZooKeeper
-Group: Development/Libraries
-Requires: python, %{name}-lib
-
-%description -n python-ZooKeeper
-Python client library for ZooKeeper.
-
-%files -n python-ZooKeeper
-%defattr(-, root, root, -)
-%doc src/contrib/zkpython/README src/contrib/zkpython/src/python/zk.py
+%doc ../%{realname}-%{version}/zookeeper-contrib/zookeeper-contrib-zkpython/README
+%doc ../%{realname}-%{version}/zookeeper-contrib/zookeeper-contrib-zkpython/src/python/zk.py
+%if 0%{?centos_ver} > 0
 %{python_sitearch}/*
+%else
+%{python2_sitearch}/*
+%endif
 
-
-%pre
-getent group zookeeper >/dev/null || groupadd -r zookeeper
-getent passwd zookeeper >/dev/null || useradd -r -g zookeeper -d / -s /sbin/nologin zookeeper
-exit 0
-
-%post
-/sbin/chkconfig --add zookeeper
-
-%preun
-if [ $1 = 0 ] ; then
-    /sbin/service zookeeper stop >/dev/null 2>&1
-    /sbin/chkconfig --del zookeeper
-fi
-
-%postun
-if [ "$1" -ge "1" ] ; then
-    /sbin/service zookeeper condrestart >/dev/null 2>&1 || :
-fi
+%files -n python3-zookeeper
+%defattr(-, root, root, -)
+%doc ../%{realname}-%{version}/zookeeper-contrib/zookeeper-contrib-zkpython/README
+%doc ../%{realname}-%{version}/zookeeper-contrib/zookeeper-contrib-zkpython/src/python/zk.py
+%{python3_sitearch}/*
 
 %changelog
-* Fri Sep 07 2018 Vincent Legoll <vincent.legoll@openio.io> - 3.4.13-1
-- Update to 3.4.13
-* Mon May 21 2018 Vincent Legoll <vincent.legoll@openio.io> - 3.4.12-2
-- Add ZOOKEEPER-critsects.patch for enhanced performance
-* Mon May 21 2018 Vincent Legoll <vincent.legoll@openio.io> - 3.4.12-1
-- Update to 3.4.12
-* Mon Nov 13 2017 Romain Acciari <romain.acciari@openio.io> - 3.4.11-1
-- Update to 3.4.11
-* Tue Oct 24 2017 Romain Acciari <romain.acciari@openio.io> - 3.4.10-1
-- Update to 3.4.10
-* Wed Dec 28 2016 Romain Acciari <romain.acciari@openio.io> - 3.4.9-1
-- Update to 3.4.9
-- Add patch ZK#2044
-* Wed Mar 16 2016 Romain Acciari <romain.acciari@openio.io> - 3.4.8-1
-- Initial release


### PR DESCRIPTION
Update zookeeper to 3.5.5.
Also package Python 2 and Python 3 client libraries.

The spec file has been tested on Opensuse Build Service, and works for both Opensuse and CentOS.
See https://build.opensuse.org/package/show/home:fvennetier:openio/zookeeper