### PR TITLE
🐛 Fix package oio-replicator unstable build versions

### DIFF
--- a/openio-sds-replicator/openio-sds-replicator.spec
+++ b/openio-sds-replicator/openio-sds-replicator.spec
@@ -1,10 +1,10 @@
 Name:           openio-sds-replicator
 
+
 %if %{?_with_test:0}%{!?_with_test:1}
 Version:        1.0.0
 Release:        1%{?dist}
 %define         tarversion %{version}
-%define         jarversion %{version}
 %define         gradlew_args -Pbuild.type=release
 %else
 # Testing purpose only. Do not modify.
@@ -12,9 +12,8 @@ Release:        1%{?dist}
 %global         shortcommit %(c=%{tag}; echo ${c:0:7})
 Version:        test%{date}.git%{shortcommit}
 Release:        0%{?dist}
-%define         gradlew_args
+%define         gradlew_args %{nil}
 %define         tarversion %{tag}
-%define         jarversion 0.5-SNAPSHOT
 Epoch:          1
 %endif
 
@@ -45,10 +44,7 @@ OpenIO SDS replicator service.
 
 %install
 %{__mkdir_p} -v $RPM_BUILD_ROOT%{_javadir}/openio-sds-replicator
-%{__install} -m755 build/libs/openio-sds-replicator-%{jarversion}-all.jar $RPM_BUILD_ROOT%{_javadir}/openio-sds-replicator/
-pushd $RPM_BUILD_ROOT%{_javadir}/openio-sds-replicator
-  %{__ln_s} openio-sds-replicator-%{jarversion}-all.jar openio-sds-replicator-all.jar
-popd
+%{__install} -m755 build/libs/openio-sds-replicator-all.jar $RPM_BUILD_ROOT%{_javadir}/openio-sds-replicator/
 
 
 %files


### PR DESCRIPTION
 ##### SUMMARY

 🐛 Fix package build for unstable versions of oio-replicator:

- The variable `gradle_args` was empty when running an unstable build, while it must be declared as `nil` in recent rpmspec
- The variable `jarversion` which was dependening on the (removed) `version.txt` file was problematic (how to get the unstable version?). It is not required as soon as https://github.com/open-io/oio-replicator/pull/42 is merged, because the resulting jar file as static name now

 ##### IMPACT
- N/A

 ##### ADDITIONAL INFORMATION

Signed-off-by: dduportal <damien.duportal@openio.io>

Follows up https://github.com/open-io/oio-replicator/pull/40